### PR TITLE
chore(ci): curl --max-time 30s -> 120s 증가

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -44,7 +44,7 @@ jobs:
               -H "Content-Type: application/json" \
               -H "x-cron-secret: ${{ secrets.CRON_SECRET }}" \
               -d '{}' \
-              --max-time 30)
+              --max-time 120)
             
             # 응답 분리
             http_code=$(echo "$response" | tail -n1)


### PR DESCRIPTION
#4 
- GitHub Actions failure 방지
- 추후 로직 개선 후 시간 재설정 필요