### PR TITLE
feat: 재구독시 기존 문제 index 이어서 전송

### DIFF
--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -50,19 +50,35 @@ export async function POST(request: NextRequest) {
       .select()
       .single();
 
-    // 재구독 시 subscriber_progress 초기화
+    // 재구독 시 기존 progress 유지 (초기화하지 않음)
     if (data) {
-      await supabaseAdmin.from("subscriber_progress").upsert(
-        {
-          subscriber_id: data.id,
-          current_problem_index: 0,
-          total_problems_sent: 0,
-        },
-        {
-          onConflict: "subscriber_id",
-          ignoreDuplicates: false,
-        }
-      );
+      // 기존 progress가 있는지 확인
+      const { data: existingProgress } = await supabaseAdmin
+        .from("subscriber_progress")
+        .select("current_problem_index, total_problems_sent")
+        .eq("subscriber_id", data.id)
+        .single();
+
+      if (!existingProgress) {
+        // 새 구독자인 경우에만 progress 생성
+        await supabaseAdmin.from("subscriber_progress").upsert(
+          {
+            subscriber_id: data.id,
+            current_problem_index: 0,
+            total_problems_sent: 0,
+          },
+          {
+            onConflict: "subscriber_id",
+            ignoreDuplicates: false,
+          }
+        );
+        console.log(`📊 새 구독자 progress 생성: ${data.email}`);
+      } else {
+        // 기존 구독자 재구독 시 progress 유지
+        console.log(
+          `📊 기존 progress 유지: ${data.email} (${existingProgress.current_problem_index}번째 문제)`
+        );
+      }
     }
 
     if (error) {


### PR DESCRIPTION
재구독시 subscriber_progress 테이블 데이터 초기화 하지 않고,
기존에 있는 데이터 사용
=> 재구독시 메일로 받지 않았던 문제 index부터 전송 시작