### PR TITLE
feat: 재구독 추적

### DIFF
--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -1,54 +1,59 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabase';
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase";
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
-    const token = searchParams.get('token');
+    const token = searchParams.get("token");
 
     if (!token) {
       return new NextResponse(
-        generateUnsubscribePage('유효하지 않은 구독 해지 링크입니다.', false),
+        generateUnsubscribePage("유효하지 않은 구독 해지 링크입니다.", false),
         {
           status: 400,
-          headers: { 'Content-Type': 'text/html; charset=utf-8' }
+          headers: { "Content-Type": "text/html; charset=utf-8" },
         }
       );
     }
 
     // Find and deactivate subscriber
     const { data, error } = await supabaseAdmin
-      .from('subscribers')
-      .update({ is_active: false })
-      .eq('unsubscribe_token', token)
+      .from("subscribers")
+      .update({
+        is_active: false,
+        last_unsubscribed_at: new Date().toISOString(),
+      })
+      .eq("unsubscribe_token", token)
       .select()
       .single();
 
     if (error || !data) {
       return new NextResponse(
-        generateUnsubscribePage('구독 해지 처리 중 오류가 발생했습니다.', false),
+        generateUnsubscribePage(
+          "구독 해지 처리 중 오류가 발생했습니다.",
+          false
+        ),
         {
           status: 404,
-          headers: { 'Content-Type': 'text/html; charset=utf-8' }
+          headers: { "Content-Type": "text/html; charset=utf-8" },
         }
       );
     }
 
     return new NextResponse(
-      generateUnsubscribePage('구독 해지가 완료되었습니다.', true),
+      generateUnsubscribePage("구독 해지가 완료되었습니다.", true),
       {
         status: 200,
-        headers: { 'Content-Type': 'text/html; charset=utf-8' }
+        headers: { "Content-Type": "text/html; charset=utf-8" },
       }
     );
-
   } catch (error) {
-    console.error('Unsubscribe API error:', error);
+    console.error("Unsubscribe API error:", error);
     return new NextResponse(
-      generateUnsubscribePage('서버 오류가 발생했습니다.', false),
+      generateUnsubscribePage("서버 오류가 발생했습니다.", false),
       {
         status: 500,
-        headers: { 'Content-Type': 'text/html; charset=utf-8' }
+        headers: { "Content-Type": "text/html; charset=utf-8" },
       }
     );
   }
@@ -99,7 +104,7 @@ function generateUnsubscribePage(message: string, success: boolean) {
         }
         .button {
             display: inline-block;
-            background: ${success ? '#10B981' : '#EF4444'};
+            background: ${success ? "#10B981" : "#EF4444"};
             color: #FFFFFF;
             padding: 12px 24px;
             border-radius: 6px;
@@ -114,8 +119,8 @@ function generateUnsubscribePage(message: string, success: boolean) {
 </head>
 <body>
     <div class="container">
-        <div class="icon">${success ? '✅' : '❌'}</div>
-        <h1>${success ? '구독 해지 완료' : '오류 발생'}</h1>
+        <div class="icon">${success ? "✅" : "❌"}</div>
+        <h1>${success ? "구독 해지 완료" : "오류 발생"}</h1>
         <p>${message}</p>
         <a href="/" class="button">홈으로 돌아가기</a>
     </div>

--- a/src/lib/cron/core.ts
+++ b/src/lib/cron/core.ts
@@ -34,6 +34,9 @@ export interface Subscriber {
   frequency: string;
   unsubscribe_token: string;
   created_at: string;
+  resubscribe_count: number;
+  last_resubscribed_at: string | null;
+  last_unsubscribed_at: string | null;
 }
 
 export interface Problem {
@@ -68,7 +71,7 @@ export async function executeCronCore(
     const { data: allSubscribers, error: subscribersError } =
       await supabaseAdmin
         .from("subscribers")
-        .select("id, email, frequency, unsubscribe_token, created_at")
+        .select("id, email, frequency, unsubscribe_token, created_at, resubscribe_count, last_resubscribed_at, last_unsubscribed_at")
         .eq("is_active", true);
 
     if (subscribersError) {
@@ -510,7 +513,7 @@ async function processSubscriber(
         logger.test(`🧪 테스트 모드: subscriber_progress 업데이트 건너뜀`);
       }
 
-      return { success: true };
+      return { success: true, alreadySent: false };
     } else {
       logger.error(
         `❌ 이메일 전송 실패: ${subscriber.email}`,

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -20,6 +20,9 @@ export type Database = {
           is_active: boolean;
           unsubscribe_token: string;
           created_at: string;
+          resubscribe_count: number;
+          last_resubscribed_at: string | null;
+          last_unsubscribed_at: string | null;
         };
         Insert: {
           id?: string;
@@ -29,6 +32,9 @@ export type Database = {
           is_active?: boolean;
           unsubscribe_token?: string;
           created_at?: string;
+          resubscribe_count?: number;
+          last_resubscribed_at?: string | null;
+          last_unsubscribed_at?: string | null;
         };
         Update: {
           id?: string;
@@ -38,6 +44,9 @@ export type Database = {
           is_active?: boolean;
           unsubscribe_token?: string;
           created_at?: string;
+          resubscribe_count?: number;
+          last_resubscribed_at?: string | null;
+          last_unsubscribed_at?: string | null;
         };
       };
       problems: {


### PR DESCRIPTION
- 구독 취소한 날짜, 재구독한 날짜, 재구독 횟수 기록
  - DB 마이그레이션 완료
  - 재구독 추적 로직 반영
- 업데이트 사항에 따른 admin-test cron 업데이트
  - 테스트 편의를 위한 관리자 계정 테스트시 중복 전송 허용