### PR TITLE
feat: 다중 문제 리스트별 재구독 추적 로직 구현 (#46)

### DIFF
--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -54,11 +54,12 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      // 특정 구독만 비활성화
+      // 특정 구독만 비활성화 (재구독 추적 포함)
       const { error: updateError } = await supabaseAdmin
         .from("subscriptions")
         .update({
           is_active: false,
+          last_unsubscribed_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
         })
         .eq("id", subscriptionId);
@@ -109,11 +110,12 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      // 해당 구독자의 모든 구독도 비활성화
+      // 해당 구독자의 모든 구독도 비활성화 (재구독 추적 포함)
       const { error: subscriptionsError } = await supabaseAdmin
         .from("subscriptions")
         .update({
           is_active: false,
+          last_unsubscribed_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
         })
         .eq("subscriber_id", data.id);

--- a/src/lib/cron/core.ts
+++ b/src/lib/cron/core.ts
@@ -36,9 +36,6 @@ export interface Subscriber {
   frequency: string;
   unsubscribe_token: string;
   created_at: string;
-  resubscribe_count: number;
-  last_resubscribed_at: string | null;
-  last_unsubscribed_at: string | null;
 }
 
 export interface Subscription {
@@ -47,6 +44,11 @@ export interface Subscription {
   problem_list_id: string;
   frequency: string;
   is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  resubscribe_count: number;
+  last_resubscribed_at: string | null;
+  last_unsubscribed_at: string | null;
   subscriber: Subscriber;
   problem_list: {
     id: string;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -20,9 +20,6 @@ export type Database = {
           is_active: boolean;
           unsubscribe_token: string;
           created_at: string;
-          resubscribe_count: number;
-          last_resubscribed_at: string | null;
-          last_unsubscribed_at: string | null;
         };
         Insert: {
           id?: string;
@@ -32,9 +29,6 @@ export type Database = {
           is_active?: boolean;
           unsubscribe_token?: string;
           created_at?: string;
-          resubscribe_count?: number;
-          last_resubscribed_at?: string | null;
-          last_unsubscribed_at?: string | null;
         };
         Update: {
           id?: string;
@@ -44,9 +38,6 @@ export type Database = {
           is_active?: boolean;
           unsubscribe_token?: string;
           created_at?: string;
-          resubscribe_count?: number;
-          last_resubscribed_at?: string | null;
-          last_unsubscribed_at?: string | null;
         };
       };
       problems: {
@@ -180,6 +171,9 @@ export type Database = {
           is_active: boolean;
           created_at: string;
           updated_at: string;
+          resubscribe_count: number;
+          last_resubscribed_at: string | null;
+          last_unsubscribed_at: string | null;
         };
         Insert: {
           id?: string;
@@ -189,6 +183,9 @@ export type Database = {
           is_active?: boolean;
           created_at?: string;
           updated_at?: string;
+          resubscribe_count?: number;
+          last_resubscribed_at?: string | null;
+          last_unsubscribed_at?: string | null;
         };
         Update: {
           id?: string;
@@ -198,6 +195,9 @@ export type Database = {
           is_active?: boolean;
           created_at?: string;
           updated_at?: string;
+          resubscribe_count?: number;
+          last_resubscribed_at?: string | null;
+          last_unsubscribed_at?: string | null;
         };
       };
       subscription_progress: {


### PR DESCRIPTION
- subscribers 테이블에서 subscriptions 테이블로 재구독 추적 필드 이동
- 각 문제 리스트별로 독립적인 재구독 횟수 및 시간 추적
- subscribe API: 문제 리스트별 재구독 추적 로직 추가
- unsubscribe API: 문제 리스트별 구독 해지 시간 기록
- TypeScript 타입 정의 업데이트 (subscribers, subscriptions)
- cron/core.ts 인터페이스 업데이트

각 구독자가 여러 문제 리스트를 동시에 구독할 수 있도록
재구독 추적을 구독자 레벨에서 구독 레벨로 변경

- DB 마이그레이션 완료